### PR TITLE
Update qosf-simulator-task.ipynb

### DIFF
--- a/qosf-simulator-task.ipynb
+++ b/qosf-simulator-task.ipynb
@@ -138,7 +138,7 @@
     "\n",
     "#### Endianness\n",
     "\n",
-    "It is important to say that different quantum programming frameworks use different orientation of bitstrings (endianness). In previous example, left bit belongs to first qubit and righ bit belongs to second qubit. This enconding is called \"big endian\".\n",
+    "It is important to say that different quantum programming frameworks use different orientation of bitstrings (endianness). In previous example, left bit belongs to first qubit and right bit belongs to second qubit. This enconding is called \"big endian\".\n",
     "\n",
     "But, in some frameworks (like Qiskit), encoding is opposite: rightmost bit belongs to first qubit and leftmost bit belongs to last qubit. This is called \"little endian\".\n",
     "\n",


### PR DESCRIPTION
line 141, spelling change 'righ bit belongs...' to 'right bit belongs...'