### PR TITLE
Update qosf-simulator-task.ipynb

### DIFF
--- a/qosf-simulator-task.ipynb
+++ b/qosf-simulator-task.ipynb
@@ -415,7 +415,7 @@
     "\n",
     "$\\mathit{CU} \\;=\\; \\vert{0}\\rangle\\!\\langle{0}\\vert \\!\\otimes\\! \\mathbf 1 \\,+\\, \\vert{1}\\rangle\\!\\langle{1}\\vert \\!\\otimes\\! U$\n",
     "\n",
-    "where ${\\mathbf 1}$ is an identity matrix of the same dimension as $U$. Here, ${\\ket{0}\\!\\bra{0}}$ and ${\\ket{1}\\!\\bra{1}}$ are projectors onto the states ${\\ket{0}}$ and ${\\ket{1}}$ of the control qubit &mdash; but we are not using them here as elements of a measurement, but to describe the effect on the other qubits depending on one or the other subspace of the state-space of the first qubit.\n",
+    "where ${\\mathbf 1}$ is an identity matrix of the same dimension as $U$. Here, ${\\vert{0}\\rangle\\!\\langle{0}\\vert}$ and ${\\vert{1}\\rangle\\!\\langle{1}\\vert}$ are projectors onto the states ${\\vert{0}\\rangle}$ and ${\\vert{1}\\rangle}$ of the control qubit &mdash; but we are not using them here as elements of a measurement, but to describe the effect on the other qubits depending on one or the other subspace of the state-space of the first qubit.\n",
     "\n",
     "We can use this to derive the matrix for the gate ${\\mathit{CX}_{1,3}}$ which performs an $X$ operation on qubit 3, coherently conditioned on the state of qubit 1, by thinking of this as a controlled-${(\\mathbf 1_2 \\!\\otimes\\! X)}$ operation on qubits 2 and 3:\n",
     "\n",


### PR DESCRIPTION
line 418 displays \ket{} and \bra in markdown cell.  Write out ket-bras the same way as line 416. 